### PR TITLE
Change git url to gitlab.com

### DIFF
--- a/packages/app-text/pdfgrep/pdfgrep.exlib
+++ b/packages/app-text/pdfgrep/pdfgrep.exlib
@@ -6,7 +6,7 @@ require sourceforge [ suffix=tar.gz ]
 SUMMARY="Search for text in pdf files"
 
 if ever is_scm ; then
-    SCM_REPOSITORY="git://gitorious.org/pdfgrep/pdfgrep.git"
+    SCM_REPOSITORY="git://gitlab.com/pdfgrep/pdfgrep.git"
     DOWNLOADS=""
     require scm-git
 fi


### PR DESCRIPTION
As pdfgrep moved to gitlab the current scm exheres does not fetch the newest updates. By changing the url to the active repo it seems to work again.